### PR TITLE
Build tensorflow from source on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,10 @@ install:
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
-
-      conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-      
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
 
 script:
   - conda build ./recipe

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ About conda-forge
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the
-conda-forge GitHub organization. The conda-forge organization contains one repository 
+conda-forge GitHub organization. The conda-forge organization contains one repository
 for each of the installable packages. Such a repository is known as a *feedstock*.
 
 A feedstock is made up of a conda recipe (the instructions on what and how to build
@@ -71,7 +71,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/tensorflow-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/tensorflow-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/tensorflow-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/tensorflow-feedstock) 
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/tensorflow-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/tensorflow-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/tensorflow-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/tensorflow-feedstock/branch/master)
 
 Current release info
@@ -92,7 +92,7 @@ install and use.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string). 
+   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
    the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
    back to 0.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -50,17 +50,17 @@ yum install -y java-1.8.0-openjdk-devel unzip zip zlib-devel rsync
 
 
 # Embarking on 3 case(s).
-    set -x
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
+#    set -x
+#    export CONDA_PY=27
+#    set +x
+#    conda build /recipe_root --quiet || exit 1
+#    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 
-    set -x
-    export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
+#    set -x
+#    export CONDA_PY=34
+#    set +x
+#    conda build /recipe_root --quiet || exit 1
+#    /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 
     set -x
     export CONDA_PY=35

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,6 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
-
  - defaults # As we need conda-build
 
 conda-build:
@@ -39,9 +38,16 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda update --yes --all
-conda install --yes conda-build
-conda info
+conda install --yes --quiet conda-forge-build-setup
+source run_conda_forge_build_setup
+
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line be updated
+# automatically.
+yum install -y java-1.8.0-openjdk-devel unzip zip zlib-devel rsync
+
 
 # Embarking on 3 case(s).
     set -x

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,14 +16,10 @@ if [ `uname` == Linux ]; then
     curl -s -L -O https://github.com/bazelbuild/bazel/archive/0.3.1.tar.gz
     tar xf 0.3.1.tar.gz
     cd bazel-0.3.1
-    #./compile.sh
-    #mkdir -p ~/bin
-    #cp output/bazel ~/bin/
+    ./compile.sh
+    mkdir -p ~/bin
+    cp output/bazel ~/bin/
     cd ..
-
-    # debug
-    pwd
-    ls
 
     # Compile tensorflow from source
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,7 +34,7 @@ if [ `uname` == Linux ]; then
     cat tensorflow/tools/swig/swig.sh
 
     # build wheel using bazel
-    bazel build -c opt //tensorflow/tools/pip_package:build_pip_package
+    bazel build --jobs 2 -c opt //tensorflow/tools/pip_package:build_pip_package
     mkdir $SRC_DIR/tensorflow_pkg
     bazel-bin/tensorflow/tools/pip_package/build_pip_package $SRC_DIR/tensorflow_pkg
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,10 +16,14 @@ if [ `uname` == Linux ]; then
     curl -s -L -O https://github.com/bazelbuild/bazel/archive/0.3.1.tar.gz
     tar xf 0.3.1.tar.gz
     cd bazel-0.3.1
-    ./compile.sh
-    mkdir -p ~/bin
-    cp output/bazel ~/bin/
+    #./compile.sh
+    #mkdir -p ~/bin
+    #cp output/bazel ~/bin/
     cd ..
+
+    # debug
+    pwd
+    ls
 
     # Compile tensorflow from source
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,11 +11,34 @@ if [ `uname` == Darwin ]; then
 fi
 
 if [ `uname` == Linux ]; then
-    if [ "$PY_VER" == "2.7" ]; then
-        pip install --no-deps https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp27-none-linux_x86_64.whl
-    elif [ "$PY_VER" == "3.4" ]; then
-        pip install --no-deps https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp34-cp34m-linux_x86_64.whl
-    elif [ "$PY_VER" == "3.5" ]; then
-        pip install --no-deps https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp35-cp35m-linux_x86_64.whl
-    fi
+
+    # Install Bazel from source
+    curl -s -L -O https://github.com/bazelbuild/bazel/archive/0.3.1.tar.gz
+    tar xf 0.3.1.tar.gz
+    cd bazel-0.3.1
+    ./compile.sh
+    mkdir -p ~/bin
+    cp output/bazel ~/bin/
+    cd ..
+
+    # Compile tensorflow from source
+
+    # Set up symlinks to python include normally performed by ./configure
+    export PYTHON_BIN_PATH=$PREFIX/bin/python
+    (./util/python/python_config.sh --setup "$PYTHON_BIN_PATH";) || exit -1
+
+    # Use conda installed swig
+    # http://stackoverflow.com/questions/33885276
+    echo "#!/bin/bash" > tensorflow/tools/swig/swig.sh
+    echo "`which swig` \"\$@\"" >> tensorflow/tools/swig/swig.sh
+    cat tensorflow/tools/swig/swig.sh
+
+    # build wheel using bazel
+    bazel build -c opt //tensorflow/tools/pip_package:build_pip_package
+    mkdir $SRC_DIR/tensorflow_pkg
+    bazel-bin/tensorflow/tools/pip_package/build_pip_package $SRC_DIR/tensorflow_pkg
+
+    # install using pip from the whl file
+    pip install --no-deps $SRC_DIR/tensorflow_pkg/*.whl
+
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "0.9.0"
 
 build:
-  number: 0
+  number: 1
   #  Google supplies 0.9.0 whl files for:
   # - Linux: Python 2.7, 3.4 and 3.5
   # - OS X: Python 2.7, 3.4 and 3.5
@@ -17,6 +17,7 @@ requirements:
   build:
     - python
     - pip
+    - swig
     - numpy >=1.10.1
     - protobuf ==3.0.0b2
     - six >=1.10.0
@@ -29,9 +30,7 @@ requirements:
 
 test:
   imports:
-    # Skip the import test on Linux as wheel file require a more recent
-    # version of GLIBC++ than the VM used to build and test package.
-    - tensorflow  # [not linux]
+    - tensorflow
 
 about:
   home: http://tensorflow.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,11 @@ package:
   name: tensorflow
   version: "0.9.0"
 
+source:
+  fn: v0.9.0.tar.gz
+  url: https://github.com/tensorflow/tensorflow/archive/v0.9.0.tar.gz
+  sha256: 3128c396af19518c642d3e590212291e1d93c5b047472a10cf3245b53adac9c9
+
 build:
   number: 1
   #  Google supplies 0.9.0 whl files for:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,5 @@
+java-1.8.0-openjdk-devel
+unzip
+zip
+zlib-devel
+rsync


### PR DESCRIPTION
Build tensorflow from source on Linux after building Bazel from source.
Requires the install of java and a few other packages using yum.
