### PR TITLE
Require mock

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.8.0"
 
 build:
-  number: 0
+  number: 1
   #  Google supplies whl files on PyPI for:
   # - Linux: Python 2.7, 3.3, 3.4, 3.5 and 3.6
   # - OS X: Python 2.7, 3.5 and 3.6
@@ -37,10 +37,9 @@ requirements:
     - grpcio >=1.8.6
     - enum34 >=1.1.6              # [py<34]
     - backports.weakref >=1.0rc1  # [py2k]
+    - mock >=2.0.0                # [py2k]
 
 test:
-  requires:
-    - mock >=2.0.0                # [py2k]
   imports:
     # Skip the import test on Linux as wheel file require a more recent
     # version of GLIBC++ than the VM used to build and test package.


### PR DESCRIPTION
Seems tensorflow requires mock at runtime, not just testing anymore:
https://github.com/tensorflow/tensorflow/search?utf8=%E2%9C%93&q=%22import+mock%22&type=Code
Encoutered this while creating gpflow recipe https://github.com/conda-forge/staged-recipes/pull/5847