### PR TITLE
Dont clobber tensorboard

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,3 +5,7 @@ IF "%PY_VER%"=="3.7" (
 	%PYTHON% -m pip install --no-deps https://pypi.org/packages/cp37/t/tensorflow/tensorflow-%PKG_VERSION%-cp37-cp37m-win_amd64.whl
 )
 if errorlevel 1 exit 1
+
+rem we dont want to clobber the tensorboard package
+del %PREFIX%\Scripts\tensorboard*
+if errorlevel 1 exit 1


### PR DESCRIPTION
tensorboard and tensorflow conflict on windows, see the gplow feedstock:

2019-06-18T06:10:04.8359933Z ERROR:conda.stderr:
2019-06-18T06:10:04.8360465Z ClobberWarning: Conda was asked to clobber an existing path.
2019-06-18T06:10:04.8360756Z   source path: C:\Miniconda\pkgs\tensorflow-1.10.0-py36_0\Scripts\tensorboard.exe
2019-06-18T06:10:04.8361064Z   target path: D:\bld\gpflow_1560837524273\_test_env\Scripts\tensorboard.exe
2019-06-18T06:10:04.8361282Z

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
