### PR TITLE
Fix requirements of tensorflow and tensorflow-base package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -167,8 +167,8 @@ outputs:
         - {{ compiler('cxx') }}     # [linux]
       # host requirements to pick up run_exports
       host:
-        - libz  # [linux]
         - libcurl  # [linux]
+        - zlib  # [linux]
 
     test:
       commands:
@@ -185,8 +185,8 @@ outputs:
         - {{ compiler('cxx') }}     # [linux]
       # host requirements to pick up run_exports
       host:
-        - libz  # [linux]
         - libcurl  # [linux]
+        - zlib  # [linux]
       run:
         - libprotobuf
         - eigen

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     - patches/unbundle_llvm.patch                                               # [linux]
 
 build:
-  number: 3
+  number: 4
   skip: True  # [not x86_64]
   skip: True  # [win and vc<14]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -130,10 +130,10 @@ outputs:
         - {{ pin_compatible('numpy') }}  # [linux]
         - numpy >=1.13.3            # [not linux]
         - six >=1.10.0
-        - {{ pin_compatible('zlib') }}  # [linux]
-        - {{ pin_compatible('libprotobuf') }}  # [linux]
-        - {{ pin_compatible('libpng') }}   # [linux]
-        - {{ pin_compatible('libcurl') }}  # [linux]
+        - zlib  # [linux]
+        - libprotobuf  # [linux]
+        - libpng  # [linux]
+        - libcurl  # [linux]
         - protobuf >=3.6.1
         - termcolor >=1.1.0
         - grpcio >=1.8.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,6 +91,10 @@ outputs:
         - tf_upgrade_v2 = tensorflow.tools.compatibility.tf_upgrade_v2_main:main
         - tensorboard = tensorboard.main:run_main
     requirements:
+      # build requirements needs to pick up the compiler run_exports
+      build:
+        - {{ compiler('c') }}       # [linux]
+        - {{ compiler('cxx') }}     # [linux]
       host:
         # conda build requirements
         - python
@@ -156,6 +160,16 @@ outputs:
     script: cp_libtensorflow.sh  # [unix]
     build:
       skip: true  # [not linux]
+    requirements:
+      # build requirements needs to pick up the compiler run_exports
+      build:
+        - {{ compiler('c') }}       # [linux]
+        - {{ compiler('cxx') }}     # [linux]
+      # host requirements to pick up run_exports
+      host:
+        - libz  # [linux]
+        - libcurl  # [linux]
+
     test:
       commands:
         - test -f $PREFIX/lib/libtensorflow.so  # [not win]
@@ -165,6 +179,14 @@ outputs:
     build:
       skip: true  # [not linux]
     requirements:
+      # build requirements needs to pick up the compiler run_exports
+      build:
+        - {{ compiler('c') }}       # [linux]
+        - {{ compiler('cxx') }}     # [linux]
+      # host requirements to pick up run_exports
+      host:
+        - libz  # [linux]
+        - libcurl  # [linux]
       run:
         - libprotobuf
         - eigen

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,7 @@ requirements:
     - enum34 >=1.1.6  # [py2k]
     - tensorflow-estimator >=1.13.0,<1.14.0a0
   run:
-    - {{ pin_subpackage('tensorflow-base', min_pin='x.x', max_pin='x.x') }}
+    - {{ pin_subpackage('tensorflow-base', exact=True) }}
 
 outputs:
   - name: tensorflow-base


### PR DESCRIPTION
* Make the pinning between tensorflow and tensorflow-base exact to prevent mixed channel installs
* Use run_exports to set the correct run requirements for the various outputs.