### PR TITLE
[ci-skip] Remove dhirschfeld from maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -215,7 +215,6 @@ extra:
     - waitingkuo
     - ghego
     - hajapy
-    - dhirschfeld
     - gilbertfrancois
     - dougalsutherland
     - farhantejani


### PR DESCRIPTION
As a conda/tensorflow user I once put in a PR to update tensorflow but I don't have the expertise in packaging or tensorflow to add much here.

Since the recipe seems to be actively maintained by people much better qualified to do so there's not much point in my being listed as a maintainer anymore...