### PR TITLE
loosen pin on cuda-version 12 and fix finding libdevice.10.bc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,8 +84,7 @@ requirements:
     # GPU requirements for CUDA
     - cudnn      # [cuda_compiler_version != "None"]
     - nccl       # [cuda_compiler_version != "None"]
-    - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version == "11.8"]
-    - cuda-version 12   # [(cuda_compiler_version or "").startswith("12")]
+    - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
     - cuda-cupti-dev    # [(cuda_compiler_version or "").startswith("12")]
     - cuda-cudart-dev   # [(cuda_compiler_version or "").startswith("12")]
     - cuda-nvml-dev     # [(cuda_compiler_version or "").startswith("12")]
@@ -189,8 +188,7 @@ outputs:
         # GPU reuqirements
         - cudnn                   # [cuda_compiler_version != "None"]
         - nccl                    # [cuda_compiler_version != "None"]
-        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version == "11.8"]
-        - cuda-version 12   # [(cuda_compiler_version or "").startswith("12")]
+        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
         - cuda-cupti-dev    # [(cuda_compiler_version or "").startswith("12")]
         - cuda-cudart-dev   # [(cuda_compiler_version or "").startswith("12")]
         - cuda-nvml-dev     # [(cuda_compiler_version or "").startswith("12")]
@@ -353,8 +351,7 @@ outputs:
         - {{ pin_subpackage('tensorflow-base', exact=True) }}
         # Keep the cuda version here since it helps package solvers
         # decide on the cuda variant
-        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version == "11.8"]
-        - cuda-version 12   # [(cuda_compiler_version or "").startswith("12")]
+        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
       run:
         - python
         - {{ pin_subpackage('tensorflow-base', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -286,14 +286,15 @@ outputs:
       host:
         # Require python so that the CONDA_PY gets populated
         - python
+        # Keep the cuda version here since it helps package solvers
+        # decide on the cuda variant
+        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
       run:
         - python
         - {{ pin_subpackage('tensorflow-base', exact=True) }}
         - {{ pin_subpackage('tensorflow-estimator', exact=True) }}
         # avoid that people without GPUs needlessly download ~0.5-1GB
         # This also helps mamba give preference to the CPU build
-        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version == "11.8"]
-        - cuda-version 12   # [(cuda_compiler_version or "").startswith("12")]
         - __cuda  # [cuda_compiler_version != "None"]
     test:
       files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ source:
       - patches/0017-Load-cuda_build_defs-from-tsl.patch
       - patches/0018-Use-PYTHON-for-build-wheel.patch
       - patches/0019-Always-use-Linux-sed-style.patch
+      - patches/0020-Adjust-relative-path-for-libdevice.patch  # [(cuda_compiler_version or "").startswith("12")]
       # https://github.com/tensorflow/tensorflow/pull/62684
       - patches/62684.patch
   - url: https://github.com/tensorflow/estimator/archive/refs/tags/v{{ estimator_version.replace(".rc", "-rc") }}.tar.gz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ source:
     sha256: b3a9970c3c6b169c41ac2fd4375f668d3fd1b492d48b912d89415fa1522a8f50
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
   skip: true  # [python_impl == 'pypy']
   skip: true  # [py<39]
@@ -83,7 +83,8 @@ requirements:
     # GPU requirements for CUDA
     - cudnn      # [cuda_compiler_version != "None"]
     - nccl       # [cuda_compiler_version != "None"]
-    - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
+    - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version == "11.8"]
+    - cuda-version 12   # [(cuda_compiler_version or "").startswith("12")]
     - cuda-cupti-dev    # [(cuda_compiler_version or "").startswith("12")]
     - cuda-cudart-dev   # [(cuda_compiler_version or "").startswith("12")]
     - cuda-nvml-dev     # [(cuda_compiler_version or "").startswith("12")]
@@ -187,7 +188,8 @@ outputs:
         # GPU reuqirements
         - cudnn                   # [cuda_compiler_version != "None"]
         - nccl                    # [cuda_compiler_version != "None"]
-        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
+        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version == "11.8"]
+        - cuda-version 12   # [(cuda_compiler_version or "").startswith("12")]
         - cuda-cupti-dev    # [(cuda_compiler_version or "").startswith("12")]
         - cuda-cudart-dev   # [(cuda_compiler_version or "").startswith("12")]
         - cuda-nvml-dev     # [(cuda_compiler_version or "").startswith("12")]
@@ -291,7 +293,8 @@ outputs:
         - {{ pin_subpackage('tensorflow-estimator', exact=True) }}
         # avoid that people without GPUs needlessly download ~0.5-1GB
         # This also helps mamba give preference to the CPU build
-        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
+        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version == "11.8"]
+        - cuda-version 12   # [(cuda_compiler_version or "").startswith("12")]
         - __cuda  # [cuda_compiler_version != "None"]
     test:
       files:
@@ -349,7 +352,8 @@ outputs:
         - {{ pin_subpackage('tensorflow-base', exact=True) }}
         # Keep the cuda version here since it helps package solvers
         # decide on the cuda variant
-        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
+        - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version == "11.8"]
+        - cuda-version 12   # [(cuda_compiler_version or "").startswith("12")]
       run:
         - python
         - {{ pin_subpackage('tensorflow-base', exact=True) }}

--- a/recipe/patches/0020-Adjust-relative-path-for-libdevice.patch
+++ b/recipe/patches/0020-Adjust-relative-path-for-libdevice.patch
@@ -16,7 +16,7 @@ index ed2ffece..271f3141 100644
      // 'python' subdirectory (for pywrap libs). So we check two possible paths
      // relative to the current binary for the wheel-based nvcc package.
 -    for (auto path : {"/../nvidia/cuda_nvcc", "/../../nvidia/cuda_nvcc"})
-+    for (auto path : {"/../nvidia/cuda_nvcc", "/../../nvidia/cuda_nvcc", "../../../../nvvm/libdevice"})
++    for (auto path : {"/../nvidia/cuda_nvcc", "/../../nvidia/cuda_nvcc", "/../../../../nvvm/libdevice"})
        roots.emplace_back(std::string(dir) + path);
    }
  #endif  // defined(PLATFORM_POSIX) && !defined(__APPLE__)

--- a/recipe/patches/0020-Adjust-relative-path-for-libdevice.patch
+++ b/recipe/patches/0020-Adjust-relative-path-for-libdevice.patch
@@ -16,7 +16,7 @@ index ed2ffece..271f3141 100644
      // 'python' subdirectory (for pywrap libs). So we check two possible paths
      // relative to the current binary for the wheel-based nvcc package.
 -    for (auto path : {"/../nvidia/cuda_nvcc", "/../../nvidia/cuda_nvcc"})
-+    for (auto path : {"/../nvidia/cuda_nvcc", "/../../nvidia/cuda_nvcc", "/../../../../nvvm/libdevice"})
++    for (auto path : {"/../nvidia/cuda_nvcc", "/../../nvidia/cuda_nvcc", "/../../../.."})
        roots.emplace_back(std::string(dir) + path);
    }
  #endif  // defined(PLATFORM_POSIX) && !defined(__APPLE__)

--- a/recipe/patches/0020-Adjust-relative-path-for-libdevice.patch
+++ b/recipe/patches/0020-Adjust-relative-path-for-libdevice.patch
@@ -1,0 +1,25 @@
+From d0f71b5998edbd36ca0911f797f5f1fa34a67910 Mon Sep 17 00:00:00 2001
+From: Mark Harfouche <mark.harfouche@gmail.com>
+Date: Sat, 27 Jan 2024 22:27:56 -0500
+Subject: [PATCH] Adjust relative path for libdevice
+
+---
+ .../third_party/tsl/tsl/platform/default/cuda_libdevice_path.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/third_party/xla/third_party/tsl/tsl/platform/default/cuda_libdevice_path.cc b/third_party/xla/third_party/tsl/tsl/platform/default/cuda_libdevice_path.cc
+index ed2ffece..271f3141 100644
+--- a/third_party/xla/third_party/tsl/tsl/platform/default/cuda_libdevice_path.cc
++++ b/third_party/xla/third_party/tsl/tsl/platform/default/cuda_libdevice_path.cc
+@@ -51,7 +51,7 @@ std::vector<std::string> CandidateCudaRoots() {
+     // TF lib binaries are located in both the package's root dir and within a
+     // 'python' subdirectory (for pywrap libs). So we check two possible paths
+     // relative to the current binary for the wheel-based nvcc package.
+-    for (auto path : {"/../nvidia/cuda_nvcc", "/../../nvidia/cuda_nvcc"})
++    for (auto path : {"/../nvidia/cuda_nvcc", "/../../nvidia/cuda_nvcc", "../../../../nvvm/libdevice"})
+       roots.emplace_back(std::string(dir) + path);
+   }
+ #endif  // defined(PLATFORM_POSIX) && !defined(__APPLE__)
+-- 
+2.43.0
+


### PR DESCRIPTION
Closes: https://github.com/conda-forge/tensorflow-feedstock/issues/368
Closes: https://github.com/conda-forge/tensorflow-feedstock/issues/369

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
