### PR TITLE
[wip] Fix xla

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -152,7 +152,7 @@ export TF_ENABLE_XLA=1
 # We need to tell xla to find things in our prefix, not some other location
 # See https://github.com/conda-forge/tensorflow-feedstock/issues/296#issuecomment-2423371916
 sed -i.bak '\|^#define TF_CUDA_TOOLKIT_PATH|c\#define TF_CUDA_TOOLKIT_PATH "'"${PREFIX}"'"' third_party/gpus/cuda/cuda_config.h.tpl
-rm -f third_party/gpus/cuda/cuda_config.h.tpl
+rm -f third_party/gpus/cuda/cuda_config.h.tpl.bak
 
 sed -i.bak '\|^#define TF_CUDA_TOOLKIT_PATH|c\#define TF_CUDA_TOOLKIT_PATH "'"${PREFIX}"'"' third_party/xla/third_party/tsl/third_party/gpus/cuda/cuda_config.h.tpl
 rm -f third_party/xla/third_party/tsl/third_party/gpus/cuda/cuda_config.h.tpl.bak

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -148,6 +148,11 @@ if [[ "${target_platform}" == "osx-arm64" ]]; then
   export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 export TF_ENABLE_XLA=1
+
+# We need to tell xla to find things in our prefix, not some other location
+# See https://github.com/conda-forge/tensorflow-feedstock/issues/296#issuecomment-2423371916
+sed -i '\|opts\.set_xla_gpu_cuda_data_dir(|s|^\([[:space:]]*\).*|\1opts.set_xla_gpu_cuda_data_dir("'"${PREFIX}"'"),|' third_party/xla/xla/debug_options_flags.cc
+
 export BUILD_TARGET="//tensorflow/tools/pip_package:wheel //tensorflow/tools/lib_package:libtensorflow //tensorflow:libtensorflow_cc${SHLIB_EXT}"
 
 # Python settings

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -151,7 +151,11 @@ export TF_ENABLE_XLA=1
 
 # We need to tell xla to find things in our prefix, not some other location
 # See https://github.com/conda-forge/tensorflow-feedstock/issues/296#issuecomment-2423371916
-sed -i '\|opts\.set_xla_gpu_cuda_data_dir(|s|^\([[:space:]]*\).*|\1opts.set_xla_gpu_cuda_data_dir("'"${PREFIX}"'"),|' third_party/xla/xla/debug_options_flags.cc
+sed -i.bak '\|^#define TF_CUDA_TOOLKIT_PATH|c\#define TF_CUDA_TOOLKIT_PATH "'"${PREFIX}"'"' third_party/gpus/cuda/cuda_config.h.tpl
+rm -f third_party/gpus/cuda/cuda_config.h.tpl
+
+sed -i.bak '\|^#define TF_CUDA_TOOLKIT_PATH|c\#define TF_CUDA_TOOLKIT_PATH "'"${PREFIX}"'"' third_party/xla/third_party/tsl/third_party/gpus/cuda/cuda_config.h.tpl
+rm -f third_party/xla/third_party/tsl/third_party/gpus/cuda/cuda_config.h.tpl.bak
 
 export BUILD_TARGET="//tensorflow/tools/pip_package:wheel //tensorflow/tools/lib_package:libtensorflow //tensorflow:libtensorflow_cc${SHLIB_EXT}"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.17.0" %}
 {% set estimator_version = "2.15.0" %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.17.0" %}
 {% set estimator_version = "2.15.0" %}
-{% set build = 4 %}
+{% set build = 5 %}
 
 {% if cuda_compiler_version != "None" %}
 {% set build = build + 200 %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -98,6 +98,7 @@ requirements:
     - cuda-cupti-dev    # [(cuda_compiler_version or "").startswith("12")]
     - cuda-cudart-dev   # [(cuda_compiler_version or "").startswith("12")]
     - cuda-nvml-dev     # [(cuda_compiler_version or "").startswith("12")]
+    - cuda-nvvm-tools   # [(cuda_compiler_version or "").startswith("12")]
     - cuda-nvtx-dev     # [(cuda_compiler_version or "").startswith("12")]
     - libcublas-dev     # [(cuda_compiler_version or "").startswith("12")]
     - libcusolver-dev   # [(cuda_compiler_version or "").startswith("12")]


### PR DESCRIPTION
So i think the problem is that something changed between cuda 12.0 and 12.2. For specificity, the package 
`cuda-nvvm-tools` does not exist for cuda 12.0.



Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
