### PR TITLE
[ci skip] fix typo for osx

### DIFF
--- a/recipe/cp_libtensorflow_framework.sh
+++ b/recipe/cp_libtensorflow_framework.sh
@@ -3,7 +3,7 @@ mkdir -p ${PWD}/tarball
 tar -C ${PWD}/tarball -xzf $SRC_DIR/libtensorflow.tar.gz
 mkdir -p ${PREFIX}/lib
 if [[ "$target_platform" == "osx-"* ]]; then
-  mv ${PWD}/tarball/lib/libtensorflow_framework.*.dylib ${PREFIX}/lib
+  mv ${PWD}/tarball/lib/libtensorflow_framework.*dylib ${PREFIX}/lib
 else
   mv ${PWD}/tarball/lib/libtensorflow_framework.so* ${PREFIX}/lib
 fi


### PR DESCRIPTION
Since macos is not built on CI, skip CI