### PR TITLE
Migrate Off Decommissioned Runner Labels

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,9 +6,9 @@ cxx_compiler_version:           # [aarch64]
   - 11                          # [aarch64]
   - 11                          # [aarch64]
 
-github_actions_labels:          # [unix]
-- cirun-openstack-cpu-2xlarge   # [linux]
-- cirun-macos-m4-large          # [osx]
+github_actions_labels:                              # [unix]
+- ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg   # [linux]
+- cirun-macos-m4-large                              # [osx]
 microarch_level:
 - 1
 # hmaarrfk -- temporary, uncomment during actual build


### PR DESCRIPTION
Migrate off decommissioned runner. See https://github.com/conda-forge/admin-requests/pull/1982

See also failures here due to runner timeout (runner label does not exist anymore): https://github.com/conda-forge/tensorflow-feedstock/actions/runs/23927085498/job/69786105349?pr=480